### PR TITLE
src: support setting explicit credentials file path in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ You can also use custom credential path like:
 ALIBABA_CLOUD_CREDENTIALS_FILE=/path/to/your/credential node app.js
 ```
 
+Similarly, we also support setting explicit credentials file path like:
+
+```js
+const KmsClient = require('@alicloud/kms-sdk');
+const Credentials = require('@alicloud/credentials');
+const client = new KmsClient({
+  endpoint: 'kms.cn-hangzhou.aliyuncs.com', // check this from kms console
+  credential: new Credentials({
+    credentialsFile: '/path/to/your/credential'
+    profile: 'kms-demo'
+  })
+});
+```
+
 ## Test & Coverage
 
 * run test

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -15,6 +15,22 @@ class Credentials {
   }
 
   load() {
+    // user config first
+    if (this.option.credentialsFile) {
+      const credentialsFile = this.option.credentialsFile;
+      if (!fs.existsSync(credentialsFile)) {
+        throw new Error(`Credentials file ${credentialsFile} cannot be empty`);
+      }
+      // check read permission
+      try {
+        fs.accessSync(credentialsFile, fs.constants.R_OK);
+      } catch (e) {
+        throw new Error(`Has no read permission to credentials file ${credentialsFile}`);
+      }
+      this.credentials = this.parse(credentialsFile);
+      return;
+    }
+
     // set ak env
     if (process.env.ALIBABA_CLOUD_ACCESS_KEY_ID && process.env.ALIBABA_CLOUD_ACCESS_KEY_SECRET) {
       this.credentials = {

--- a/test/fixtures/credentials
+++ b/test/fixtures/credentials
@@ -19,3 +19,9 @@ access_key_id = access-key-id-03
 access_key_secret = access-key-secret-03
 role_arn = acs:ram::demo:role/demo
 role_session_name = demo
+
+[demo6]
+enable = true
+type = access_key
+access_key_id = access-key-id-06
+access_key_secret = access-key-secret-06


### PR DESCRIPTION
支持在 credentials 模块的构造函数配置中显式传入自定义的 credentials 文件路径（用户配置优先）

```js
const path = require('path');
const KmsClient = require('@alicloud/kms-sdk');
const Credentials = require('@alicloud/credentials');

const client = new KmsClient({
  endpoint: 'kms.cn-hangzhou.aliyuncs.com', // check this from kms console
  credential: new Credentials({
    credentialsFile: path.join(__dirname, '../config/credentials'),
    profile: 'kms-demo'
  })
});
```